### PR TITLE
Fix velocity threshold; change unit to °/s

### DIFF
--- a/cateyes/classification.py
+++ b/cateyes/classification.py
@@ -276,7 +276,7 @@ def classify_velocity(x, y, time, threshold, return_discrete=False):
     threshold : float
         The maximally allowed velocity after which a sample should be 
         classified as "Saccade". Threshold can be interpreted as
-        `gaze_units/ms`, with `gaze_units` being the spatial unit of 
+        `gaze_units/s`, with `gaze_units` being the spatial unit of 
         your eyetracking data (e.g. pixels, cm, degrees).
     return_discrete : bool
         If True, returns the output in discrete format, if False, in
@@ -299,7 +299,7 @@ def classify_velocity(x, y, time, threshold, return_discrete=False):
     else:
         times = np.arange(0, len(x), 1 / time)
         sfreq = time
-    sample_thresh = sfreq * threshold / 1000
+    sample_thresh = threshold/sfreq
     
     # calculate movement velocities
     gaze = np.stack([x, y])


### PR DESCRIPTION
We noticed today, during class, that the threshold for velicity is a bit funky.

Indeed, I think the threshold might have been calculated incorrectly 
```sfreq*threshold/1000```
Which would mean with sfreq of 20
`20*(200/1000)/1000 =>0.002°/sample`, which seems completely off.

With my implementation:
``` threshold/sfreq```
(now threshold in °/s not °/ms)
`20*200=>4000°/sample` something reasonable for 20Hz.

Maybe I missed something, though, haven't looked in too much detail.

Cheers, Bene